### PR TITLE
Accept reject pet

### DIFF
--- a/app/controllers/admin_applications_controller.rb
+++ b/app/controllers/admin_applications_controller.rb
@@ -2,4 +2,10 @@ class AdminApplicationsController < ApplicationController
   def show
     @application = Application.find(params[:id])
   end
+
+  def update
+    app = PetApplication.where(application_id: params[:id]).where(pet_id: params[:pet_id])
+    app.update(status: params[:status])
+    redirect_to "/admin/applications/#{params[:id]}"
+  end
 end

--- a/app/controllers/admin_applications_controller.rb
+++ b/app/controllers/admin_applications_controller.rb
@@ -1,0 +1,5 @@
+class AdminApplicationsController < ApplicationController
+  def show
+    @application = Application.find(params[:id])
+  end
+end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -9,6 +9,10 @@ class Pet < ApplicationRecord
     shelter.name
   end
 
+  def app_status(app_id)
+    pet_applications.where(application_id: app_id).first.status
+  end
+
   def self.adoptable
     where(adoptable: true)
   end

--- a/app/views/admin_applications/show.html.erb
+++ b/app/views/admin_applications/show.html.erb
@@ -1,0 +1,11 @@
+<h1>Pets Applied for by <%= @application.name %></h1>
+
+<% @application.pets.each do |pet| %>
+<div id="pet<%= pet.id %>">
+  <% if pet.app_status(@application.id).nil?%>
+  <%= button_to "Approve #{pet.name}", "/admin/applications/#{@application.id}", method: :patch, params: {status: "Approved", pet_id: "#{pet.id}"} %>
+  <% else %>
+  <p><%= "#{pet.name}: #{pet.app_status(@application.id)}" %></p>
+  <% end %>
+  </div>
+  <% end %>

--- a/app/views/admin_applications/show.html.erb
+++ b/app/views/admin_applications/show.html.erb
@@ -4,6 +4,7 @@
 <div id="pet<%= pet.id %>">
   <% if pet.app_status(@application.id).nil?%>
   <%= button_to "Approve #{pet.name}", "/admin/applications/#{@application.id}", method: :patch, params: {status: "Approved", pet_id: "#{pet.id}"} %>
+  <%= button_to "Reject #{pet.name}", "/admin/applications/#{@application.id}", method: :patch, params: {status: "Rejected", pet_id: "#{pet.id}"} %>
   <% else %>
   <p><%= "#{pet.name}: #{pet.app_status(@application.id)}" %></p>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,4 +45,5 @@ Rails.application.routes.draw do
   post '/pet_applications/new', to: 'pet_applications#create'
 
   get '/admin/shelters', to: 'admin_shelters#index'
+  get '/admin/applications/:id', to: 'admin_applications#show'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,4 +46,5 @@ Rails.application.routes.draw do
 
   get '/admin/shelters', to: 'admin_shelters#index'
   get '/admin/applications/:id', to: 'admin_applications#show'
+  patch '/admin/applications/:id', to: 'admin_applications#update'
 end

--- a/db/migrate/20220523161129_add_status_to_pet_applications.rb
+++ b/db/migrate/20220523161129_add_status_to_pet_applications.rb
@@ -1,0 +1,5 @@
+class AddStatusToPetApplications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pet_applications, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_20_212332) do
+ActiveRecord::Schema.define(version: 2022_05_23_161129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2022_05_20_212332) do
     t.bigint "application_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status"
     t.index ["application_id"], name: "index_pet_applications_on_application_id"
     t.index ["pet_id"], name: "index_pet_applications_on_pet_id"
   end

--- a/spec/features/admin/admin_applications/show_spec.rb
+++ b/spec/features/admin/admin_applications/show_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'admin applications show page', type: :feature do
           street_address: '-1 Bermuda trgl',
           city: 'Atlantis',
           state: 'Confusion',
-          zip_code: 42069,
+          zip_code: 42070,
           description: "I'm really lonely.",
           status: 'Pending'
       )
@@ -21,8 +21,35 @@ RSpec.describe 'admin applications show page', type: :feature do
 
       visit "/admin/applications/#{application1.id}"
 
-      expect(page).to have_content(pet_1.name)
-      expect(page).to have_content(pet_2.name)
+      expect(page).to have_button("Approve #{pet_1.name}")
+      expect(page).to have_button("Approve #{pet_2.name}")
+    end
+
+    it 'shows pet name and aproval indicator on application show page after button clicked' do
+      shelter_1 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
+      pet_1 = shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true)
+      pet_2 = shelter_1.pets.create(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true)
+
+      application1 = Application.create!(
+          name: 'Waldo Werziat',
+          street_address: '-1 Bermuda trgl',
+          city: 'Atlantis',
+          state: 'Confusion',
+          zip_code: 42070,
+          description: "I'm really lonely.",
+          status: 'Pending'
+      )
+      pet_application_1 = PetApplication.create!(pet: pet_1, application: application1)
+      pet_application_2 = PetApplication.create!(pet: pet_2, application: application1)
+
+      visit "/admin/applications/#{application1.id}"
+
+      within "#pet#{pet_1.id}" do
+        click_button("Approve #{pet_1.name}")
+
+        expect(page).to have_current_path("/admin/applications/#{application1.id}")
+        expect(page).to have_content("#{pet_1.name}: Approved")
+      end
     end
   end
 end

--- a/spec/features/admin/admin_applications/show_spec.rb
+++ b/spec/features/admin/admin_applications/show_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'admin applications show page', type: :feature do
       pet_application_1 = PetApplication.create!(pet: pet_1, application: application1)
       pet_application_2 = PetApplication.create!(pet: pet_2, application: application1)
 
-      visit "/admin/applications/:id"
+      visit "/admin/applications/#{application1.id}"
 
       expect(page).to have_content(pet_1.name)
       expect(page).to have_content(pet_2.name)

--- a/spec/features/admin/admin_applications/show_spec.rb
+++ b/spec/features/admin/admin_applications/show_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'admin applications show page', type: :feature do
+  describe 'Approving a pet for adoption' do
+    it 'Shows a button for each pet needing approval/rejection' do
+      shelter_1 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
+      pet_1 = shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true)
+      pet_2 = shelter_1.pets.create(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true)
+
+      application1 = Application.create!(
+          name: 'Waldo Werziat',
+          street_address: '-1 Bermuda trgl',
+          city: 'Atlantis',
+          state: 'Confusion',
+          zip_code: 42069,
+          description: "I'm really lonely.",
+          status: 'Pending'
+      )
+      pet_application_1 = PetApplication.create!(pet: pet_1, application: application1)
+      pet_application_2 = PetApplication.create!(pet: pet_2, application: application1)
+
+      visit "/admin/applications/:id"
+
+      expect(page).to have_content(pet_1.name)
+      expect(page).to have_content(pet_2.name)
+    end
+  end
+end

--- a/spec/features/admin/admin_applications/show_spec.rb
+++ b/spec/features/admin/admin_applications/show_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'admin applications show page', type: :feature do
-  describe 'Approving a pet for adoption' do
+  describe 'Approving/Rejecting a pet for adoption' do
     it 'Shows a button for each pet needing approval/rejection' do
       shelter_1 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
       pet_1 = shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true)
@@ -23,9 +23,11 @@ RSpec.describe 'admin applications show page', type: :feature do
 
       expect(page).to have_button("Approve #{pet_1.name}")
       expect(page).to have_button("Approve #{pet_2.name}")
+      expect(page).to have_button("Reject #{pet_1.name}")
+      expect(page).to have_button("Reject #{pet_2.name}")
     end
 
-    it 'shows pet name and aproval indicator on application show page after button clicked' do
+    it 'shows pet name and approval indicator on application show page after approve button is clicked' do
       shelter_1 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
       pet_1 = shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true)
       pet_2 = shelter_1.pets.create(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true)
@@ -50,6 +52,71 @@ RSpec.describe 'admin applications show page', type: :feature do
         expect(page).to have_current_path("/admin/applications/#{application1.id}")
         expect(page).to have_content("#{pet_1.name}: Approved")
       end
+    end
+
+    it 'shows pet name and rejection indicator on application show page after reject button is clicked' do
+      shelter_1 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
+      pet_1 = shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true)
+      pet_2 = shelter_1.pets.create(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true)
+
+      application1 = Application.create!(
+          name: 'Waldo Werziat',
+          street_address: '-1 Bermuda trgl',
+          city: 'Atlantis',
+          state: 'Confusion',
+          zip_code: 42070,
+          description: "I'm really lonely.",
+          status: 'Pending'
+      )
+      pet_application_1 = PetApplication.create!(pet: pet_1, application: application1)
+      pet_application_2 = PetApplication.create!(pet: pet_2, application: application1)
+
+      visit "/admin/applications/#{application1.id}"
+
+      within "#pet#{pet_1.id}" do
+        click_button("Reject #{pet_1.name}")
+
+        expect(page).to have_current_path("/admin/applications/#{application1.id}")
+        expect(page).to have_content("#{pet_1.name}: Rejected")
+      end
+    end
+
+    it 'shows pet name and aproval indicator on application show page after button clicked' do
+      shelter_1 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
+      pet_1 = shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true)
+      pet_2 = shelter_1.pets.create(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true)
+
+      application1 = Application.create!(
+          name: 'Waldo Werziat',
+          street_address: '-1 Bermuda trgl',
+          city: 'Atlantis',
+          state: 'Confusion',
+          zip_code: 42070,
+          description: "I'm really lonely.",
+          status: 'Pending'
+      )
+      pet_application_1 = PetApplication.create!(pet: pet_1, application: application1)
+      pet_application_2 = PetApplication.create!(pet: pet_2, application: application1)
+
+      visit "/admin/applications/#{application1.id}"
+
+      within "#pet#{pet_1.id}" do
+        click_button("Approve #{pet_1.name}")
+
+
+        expect(page).to have_current_path("/admin/applications/#{application1.id}")
+        expect(page).to have_content("#{pet_1.name}: Approved")
+      end
+
+      within "#pet#{pet_2.id}" do
+        click_button("Reject #{pet_2.name}")
+
+        expect(page).to have_current_path("/admin/applications/#{application1.id}")
+        expect(page).to have_content("#{pet_2.name}: Rejected")
+      end
+
+      expect(page).to have_content("#{pet_2.name}: Rejected")
+      expect(page).to have_content("#{pet_1.name}: Approved")
     end
   end
 end

--- a/spec/models/pet_application_spec.rb
+++ b/spec/models/pet_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe PetApplication, type: :model do 
-    it { should belong_to :pet }
-    it { should belong_to :application }
+RSpec.describe PetApplication, type: :model do
+  it { should belong_to :pet }
+  it { should belong_to :application }
 end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -41,5 +41,41 @@ RSpec.describe Pet, type: :model do
         expect(@pet_3.shelter_name).to eq(@shelter_1.name)
       end
     end
+
+    describe '.app_status' do
+      it 'retrieves the pet_application status based off arguments' do
+        shelter_1 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
+        pet_1 = shelter_1.pets.create(name: 'Mr. Pirate', breed: 'tuxedo shorthair', age: 5, adoptable: true)
+        pet_2 = shelter_1.pets.create(name: 'Clawdia', breed: 'shorthair', age: 3, adoptable: true)
+
+        application1 = Application.create!(
+            name: 'Waldo Werziat',
+            street_address: '-1 Bermuda trgl',
+            city: 'Atlantis',
+            state: 'Confusion',
+            zip_code: 42070,
+            description: "I'm really lonely.",
+            status: 'Pending'
+        )
+
+        application2 = Application.create!(
+            name: 'Carol Baskins',
+            street_address: '12802 Easy St',
+            city: 'Tampa',
+            state: 'FL',
+            zip_code: 33625,
+            description: 'I just really love animals more than that other guy',
+            status: 'Pending'
+        )
+
+        pet_application_1 = PetApplication.create!(pet: pet_1, application: application1)
+        pet_application_2 = PetApplication.create!(pet: pet_2, application: application1, status: "Approved")
+        pet_application_3 = PetApplication.create!(pet: pet_1, application: application2, status: "Rejected")
+
+        expect(pet_1.app_status(pet_1.id, application1.id)).to eq(NULL)
+        expect(pet_2.app_status(pet_2.id, application1.id)).to eq("Approved")
+        expect(pet_1.app_status(pet_1.id, application2.id)).to eq("Rejected")
+      end
+    end
   end
 end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -72,9 +72,9 @@ RSpec.describe Pet, type: :model do
         pet_application_2 = PetApplication.create!(pet: pet_2, application: application1, status: "Approved")
         pet_application_3 = PetApplication.create!(pet: pet_1, application: application2, status: "Rejected")
 
-        expect(pet_1.app_status(pet_1.id, application1.id)).to eq(NULL)
-        expect(pet_2.app_status(pet_2.id, application1.id)).to eq("Approved")
-        expect(pet_1.app_status(pet_1.id, application2.id)).to eq("Rejected")
+        expect(pet_1.app_status(application1.id)).to eq(nil)
+        expect(pet_2.app_status(application1.id)).to eq("Approved")
+        expect(pet_1.app_status(application2.id)).to eq("Rejected")
       end
     end
   end


### PR DESCRIPTION
Add functionality for accepting and rejecting pets on admin application page.
Includes pet instance method and model testing, as well as feature testing.
All tests passing, simplecov for model and feature at 100%.